### PR TITLE
feat: autonomous coding agent with streaming, self-correction, and bi-directional comms

### DIFF
--- a/src/app/api/generation/[jobId]/cancel/route.ts
+++ b/src/app/api/generation/[jobId]/cancel/route.ts
@@ -1,0 +1,36 @@
+import { auth } from "@/lib/auth";
+import { getGenerationJobById, markGenerationJobFailed } from "@/lib/generation-jobs";
+import { getRun } from "workflow/api";
+import { headers } from "next/headers";
+
+export const runtime = "nodejs";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const { jobId } = await params;
+
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const job = await getGenerationJobById(jobId);
+  if (!job) {
+    return Response.json({ error: "Job not found" }, { status: 404 });
+  }
+
+  if (job.workflowRunId) {
+    try {
+      const run = getRun(job.workflowRunId);
+      await run.cancel();
+    } catch {
+      // Run may have already finished — ignore
+    }
+  }
+
+  await markGenerationJobFailed(jobId, "Cancelled by user");
+
+  return Response.json({ ok: true });
+}

--- a/src/app/api/generation/[jobId]/respond/route.ts
+++ b/src/app/api/generation/[jobId]/respond/route.ts
@@ -1,0 +1,41 @@
+import { auth } from "@/lib/auth";
+import { getGenerationJobById } from "@/lib/generation-jobs";
+import { resumeHook } from "workflow/api";
+import { headers } from "next/headers";
+import { z } from "zod";
+
+export const runtime = "nodejs";
+
+const bodySchema = z.object({
+  hookToken: z.string().min(1),
+  answer: z.string(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const { jobId } = await params;
+
+  // Authenticate
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const job = await getGenerationJobById(jobId);
+  if (!job) {
+    return Response.json({ error: "Job not found" }, { status: 404 });
+  }
+
+  const body = bodySchema.safeParse(await request.json());
+  if (!body.success) {
+    return Response.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const { hookToken, answer } = body.data;
+
+  await resumeHook(hookToken, { answer });
+
+  return Response.json({ ok: true });
+}

--- a/src/app/api/generation/[jobId]/stream/route.ts
+++ b/src/app/api/generation/[jobId]/stream/route.ts
@@ -1,0 +1,89 @@
+import { auth } from "@/lib/auth";
+import { getGenerationJobById } from "@/lib/generation-jobs";
+import { getRun } from "workflow/api";
+import { headers } from "next/headers";
+import { encodeEvent } from "@/codegen/stream-events";
+import type { AgentStreamEvent } from "@/codegen/stream-events";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ jobId: string }> },
+) {
+  const { jobId } = await params;
+
+  // Authenticate
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session?.user) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const job = await getGenerationJobById(jobId);
+  if (!job) {
+    return new Response("Job not found", { status: 404 });
+  }
+
+  // Verify the user has access (job belongs to the user's org)
+  // We rely on organizationId check — the session user should belong to job.organizationId
+  // Full org membership check happens at the tRPC layer; here we just verify session exists
+
+  if (!job.workflowRunId) {
+    // Job hasn't started yet — return an empty stream that immediately closes
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encodeEvent({ type: "status", status: "running" }));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  // Parse optional startIndex for reconnection
+  const url = new URL(request.url);
+  const startIndex = url.searchParams.has("startIndex")
+    ? Number(url.searchParams.get("startIndex"))
+    : undefined;
+
+  const run = getRun(job.workflowRunId);
+  const readable = run.getReadable<AgentStreamEvent>({ startIndex });
+
+  // Transform the Workflow SDK readable into SSE format
+  const encoder = new TextEncoder();
+  const sseStream = new ReadableStream({
+    async start(controller) {
+      const reader = readable.getReader();
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          controller.enqueue(encoder.encode(encodeEvent(value)));
+        }
+      } catch {
+        // Client disconnected — normal
+      } finally {
+        reader.releaseLock();
+        controller.close();
+      }
+    },
+    cancel() {
+      // Client closed connection
+    },
+  });
+
+  return new Response(sseStream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/codegen/runtime.ts
+++ b/src/codegen/runtime.ts
@@ -1,6 +1,7 @@
 import { openai } from "@ai-sdk/openai";
 import { generateText, stepCountIs, tool, type ModelMessage } from "ai";
 import z from "zod";
+import { createHook } from "workflow";
 import {
   FRAGMENT_TITLE_PROMPT,
   PROMPT,
@@ -164,6 +165,21 @@ function createAgentTools(
         const success = result.exitCode === 0;
         emit({ type: "tool_result", tool: "installPackage", result: { success, packages: safe } });
         return { success, output: result.stdout.slice(0, 300) };
+      },
+    }),
+
+    askUser: tool({
+      description: "Ask the user a clarifying question and wait for their answer. Use sparingly — only when the prompt is genuinely ambiguous and the answer will materially change what you build.",
+      inputSchema: z.object({
+        question: z.string().describe("The question to ask the user"),
+      }),
+      execute: async ({ question }) => {
+        // Create a workflow hook — this suspends the step until resumeHook is called
+        const hook = createHook<{ answer: string }>();
+        emit({ type: "ask_user", question, hookToken: hook.token });
+        // Await the hook — execution pauses here until the user responds via POST /api/generation/[jobId]/respond
+        const response = await hook;
+        return { answer: response.answer };
       },
     }),
 

--- a/src/codegen/runtime.ts
+++ b/src/codegen/runtime.ts
@@ -7,118 +7,290 @@ import {
   RESPONSE_PROMPT,
 } from "@/prompt";
 import type { CodegenHistoryMessage } from "@/codegen/history";
-import {
-  resolveFallbackModel,
-  resolveProjectModel,
-  type ProjectModelKey,
-} from "@/codegen/models";
 import type { SandboxAdapter } from "@/codegen/sandbox";
 
 const TASK_SUMMARY_REGEX = /<task_summary>\s*([\s\S]*?)\s*<\/task_summary>/i;
 
+// Commands the agent is never allowed to run directly
+const BLOCKED_COMMANDS = [
+  /^\s*npm\s+run\s+(dev|build|start)/i,
+  /^\s*next\s+(dev|build|start)/i,
+  /^\s*yarn\s+(dev|build|start)/i,
+  /^\s*pnpm\s+(dev|build|start)/i,
+  /^\s*bun\s+(run\s+)?(dev|build|start)/i,
+];
+
+function isBlockedCommand(command: string): boolean {
+  return BLOCKED_COMMANDS.some((re) => re.test(command));
+}
+
 export type CodegenRunResult = {
   summary: string | undefined;
   files: Record<string, string>;
+  buildError?: string;
+};
+
+export type AgentStreamEvent =
+  | { type: "status"; status: "running" | "building" | "fixing" | "waiting_for_user" | "completed" | "failed" }
+  | { type: "tool_start"; tool: string; args: Record<string, unknown> }
+  | { type: "tool_result"; tool: string; result: unknown }
+  | { type: "text_delta"; content: string }
+  | { type: "build_result"; pass: boolean; errors?: string; attempt: number }
+  | { type: "fix_attempt"; attempt: number; maxAttempts: number }
+  | { type: "ask_user"; question: string; hookToken: string }
+  | { type: "done"; summary: string }
+  | { type: "error"; message: string }
+
+export type AgentStreamWriter = {
+  write(event: AgentStreamEvent): void;
 };
 
 function toModelMessages(history: CodegenHistoryMessage[]): ModelMessage[] {
-  return history.map((message) => ({
-    role: message.role,
-    content: message.content,
+  return history.map((msg) => ({
+    role: msg.role,
+    content: msg.content,
   }));
 }
 
-export function extractTaskSummary(value: string) {
-  const match = TASK_SUMMARY_REGEX.exec(value);
-  return match?.[1]?.trim();
+export function extractTaskSummary(value: string): string | undefined {
+  return TASK_SUMMARY_REGEX.exec(value)?.[1]?.trim();
 }
 
-function createCodegenTools(sandbox: SandboxAdapter, files: Record<string, string>) {
+function createAgentTools(
+  sandbox: SandboxAdapter,
+  files: Record<string, string>,
+  stream?: AgentStreamWriter,
+) {
+  function emit(event: AgentStreamEvent) {
+    stream?.write(event);
+  }
+
   return {
-    terminal: tool({
-      description: "Use the terminal to run commands",
+    writeFile: tool({
+      description: "Write or overwrite a single file in the sandbox. Use relative paths (e.g. 'app/page.tsx').",
       inputSchema: z.object({
-        command: z.string(),
+        path: z.string().describe("Relative file path, e.g. 'app/page.tsx'"),
+        content: z.string().describe("Full file content"),
       }),
-      execute: async ({ command }) => sandbox.runCommand(command),
-    }),
-    createOrUpdateFiles: tool({
-      description: "Create or update files in the sandbox",
-      inputSchema: z.object({
-        files: z.array(
-          z.object({
-            path: z.string(),
-            content: z.string(),
-          }),
-        ),
-      }),
-      execute: async ({ files: fileBatch }) => {
-        await sandbox.writeFiles(fileBatch);
-
-        for (const file of fileBatch) {
-          files[file.path] = file.content;
-        }
-
-        return {
-          updatedPaths: fileBatch.map((file) => file.path),
-        };
+      execute: async ({ path, content }) => {
+        emit({ type: "tool_start", tool: "writeFile", args: { path } });
+        await sandbox.writeFile(path, content);
+        files[path] = content;
+        const result = { written: path };
+        emit({ type: "tool_result", tool: "writeFile", result });
+        return result;
       },
     }),
-    readFiles: tool({
-      description: "Read files from the sandbox",
+
+    readFile: tool({
+      description: "Read the full content of a single file. Use the actual sandbox path (e.g. '/home/user/app/page.tsx').",
       inputSchema: z.object({
-        files: z.array(z.string()),
+        path: z.string().describe("Absolute sandbox path, e.g. '/home/user/app/page.tsx'"),
       }),
-      execute: async ({ files: paths }) => {
-        return sandbox.readFiles(paths);
+      execute: async ({ path }) => {
+        emit({ type: "tool_start", tool: "readFile", args: { path } });
+        const content = await sandbox.readFile(path);
+        emit({ type: "tool_result", tool: "readFile", result: { path, length: content.length } });
+        return { path, content };
+      },
+    }),
+
+    listDirectory: tool({
+      description: "List files and directories at a given path in the sandbox.",
+      inputSchema: z.object({
+        path: z.string().describe("Absolute sandbox path, e.g. '/home/user/app'"),
+      }),
+      execute: async ({ path }) => {
+        emit({ type: "tool_start", tool: "listDirectory", args: { path } });
+        const entries = await sandbox.listDirectory(path);
+        emit({ type: "tool_result", tool: "listDirectory", result: { count: entries.length } });
+        return entries;
+      },
+    }),
+
+    searchFiles: tool({
+      description: "Search for text across source files using grep. Returns matching lines with file names and line numbers.",
+      inputSchema: z.object({
+        pattern: z.string().describe("Literal text to search for"),
+        path: z.string().optional().describe("Directory to search in. Defaults to /home/user"),
+      }),
+      execute: async ({ pattern, path }) => {
+        const searchDir = path ?? "/home/user";
+        emit({ type: "tool_start", tool: "searchFiles", args: { pattern, path: searchDir } });
+        // Write pattern to a temp file to avoid any shell interpolation
+        const tmpFile = "/tmp/grep_pattern_" + Date.now();
+        await sandbox.writeFile(tmpFile, pattern);
+        const result = await sandbox.runCommand(
+          `grep -rn --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' -f ${tmpFile} ${searchDir} 2>/dev/null | head -50; rm -f ${tmpFile}`
+        );
+        const output = result.stdout || "(no matches)";
+        emit({ type: "tool_result", tool: "searchFiles", result: { lines: output.split("\n").length } });
+        return output;
+      },
+    }),
+
+    terminal: tool({
+      description: "Run a shell command in the sandbox. Cannot run dev/build/start scripts.",
+      inputSchema: z.object({
+        command: z.string().describe("Shell command to run"),
+      }),
+      execute: async ({ command }) => {
+        if (isBlockedCommand(command)) {
+          return { error: `Blocked: cannot run dev/build/start scripts. The dev server is already running with hot reload.` };
+        }
+        emit({ type: "tool_start", tool: "terminal", args: { command } });
+        const result = await sandbox.runCommand(command);
+        const output = result.stdout + (result.stderr ? `\nSTDERR: ${result.stderr}` : "");
+        emit({ type: "tool_result", tool: "terminal", result: { exitCode: result.exitCode } });
+        return { exitCode: result.exitCode, output };
+      },
+    }),
+
+    installPackage: tool({
+      description: "Install npm packages before importing them. Use this for any library that isn't pre-installed.",
+      inputSchema: z.object({
+        packages: z.array(z.string()).describe("Package names to install, e.g. ['date-fns', 'recharts']"),
+      }),
+      execute: async ({ packages }) => {
+        // Validate package names to prevent injection (only allow npm-safe chars)
+        const safe = packages.filter((p) => /^[@a-zA-Z0-9/_\-\.]+$/.test(p));
+        if (safe.length !== packages.length) {
+          return { error: "Invalid package name detected." };
+        }
+        emit({ type: "tool_start", tool: "installPackage", args: { packages: safe } });
+        const result = await sandbox.runCommand(
+          "npm install " + safe.join(" ") + " --yes 2>&1"
+        );
+        const success = result.exitCode === 0;
+        emit({ type: "tool_result", tool: "installPackage", result: { success, packages: safe } });
+        return { success, output: result.stdout.slice(0, 300) };
+      },
+    }),
+
+    // Legacy batch tool — kept so the system prompt instructions still work
+    createOrUpdateFiles: tool({
+      description: "Create or update multiple files at once.",
+      inputSchema: z.object({
+        files: z.array(z.object({ path: z.string(), content: z.string() })),
+      }),
+      execute: async ({ files: fileBatch }) => {
+        emit({ type: "tool_start", tool: "createOrUpdateFiles", args: { count: fileBatch.length } });
+        await sandbox.writeFiles(fileBatch);
+        for (const f of fileBatch) {
+          files[f.path] = f.content;
+        }
+        const result = { updatedPaths: fileBatch.map((f) => f.path) };
+        emit({ type: "tool_result", tool: "createOrUpdateFiles", result });
+        return result;
       },
     }),
   };
 }
 
-async function generatePlainText(system: string, prompt: string) {
-  const { text } = await generateText({
-    model: openai(resolveFallbackModel()),
-    system,
-    prompt,
-  });
-
-  return text.trim();
-}
+const MAX_BUILD_FIX_ATTEMPTS = 3;
+const MAX_AGENT_STEPS = 25;
 
 export async function runCodegenAgent(input: {
   prompt: string;
   history: CodegenHistoryMessage[];
-  model: ProjectModelKey | undefined;
   sandbox: SandboxAdapter;
+  stream?: AgentStreamWriter;
 }): Promise<CodegenRunResult> {
   const files: Record<string, string> = {};
-  const result = await generateText({
-    model: openai(resolveProjectModel(input.model)),
-    system: PROMPT,
-    messages: [
-      ...toModelMessages(input.history),
-      {
-        role: "user",
-        content: input.prompt,
+  const tools = createAgentTools(input.sandbox, files, input.stream);
+
+  const messages: ModelMessage[] = [
+    ...toModelMessages(input.history),
+    { role: "user", content: input.prompt },
+  ];
+
+  input.stream?.write({ type: "status", status: "running" });
+
+  let fixAttempts = 0;
+
+  while (true) {
+    const result = await generateText({
+      model: openai("gpt-5.4"),
+      system: PROMPT,
+      messages,
+      tools,
+      stopWhen: stepCountIs(MAX_AGENT_STEPS),
+      onStepFinish: ({ text }) => {
+        if (text) {
+          input.stream?.write({ type: "text_delta", content: text });
+        }
       },
-    ],
-    tools: createCodegenTools(input.sandbox, files),
-    stopWhen: stepCountIs(15),
+    });
+
+    const summary = extractTaskSummary(result.text);
+
+    if (summary) {
+      // Agent declared done — run build verification
+      input.stream?.write({ type: "status", status: "building" });
+
+      const buildResult = await input.sandbox.runCommand(
+        "cd /home/user && npx next build --no-lint 2>&1"
+      );
+
+      const buildPassed = buildResult.exitCode === 0;
+      const buildErrors = buildPassed
+        ? undefined
+        : (buildResult.stderr || buildResult.stdout).slice(0, 3000);
+
+      input.stream?.write({
+        type: "build_result",
+        pass: buildPassed,
+        errors: buildErrors,
+        attempt: fixAttempts + 1,
+      });
+
+      if (buildPassed) {
+        input.stream?.write({ type: "done", summary });
+        return { summary, files };
+      }
+
+      if (fixAttempts >= MAX_BUILD_FIX_ATTEMPTS) {
+        input.stream?.write({
+          type: "error",
+          message: "Build failed after " + MAX_BUILD_FIX_ATTEMPTS + " fix attempts.",
+        });
+        return { summary, files, buildError: buildErrors };
+      }
+
+      fixAttempts++;
+      input.stream?.write({ type: "fix_attempt", attempt: fixAttempts, maxAttempts: MAX_BUILD_FIX_ATTEMPTS });
+      input.stream?.write({ type: "status", status: "fixing" });
+
+      messages.push(
+        { role: "assistant", content: result.text },
+        {
+          role: "user",
+          content: "The build failed with these errors:\n\n" + buildErrors + "\n\nPlease fix the errors. Do not explain, just fix the files and respond with <task_summary> when done.",
+        }
+      );
+
+      continue;
+    }
+
+    // Agent ran out of steps without a task_summary
+    return { summary: undefined, files };
+  }
+}
+
+export async function generateFragmentTitle(summary: string): Promise<string> {
+  const { text } = await generateText({
+    model: openai("gpt-5.4"),
+    system: FRAGMENT_TITLE_PROMPT,
+    prompt: summary,
   });
-
-  const summary = extractTaskSummary(result.text);
-
-  return {
-    summary,
-    files,
-  };
+  return text.trim();
 }
 
-export async function generateFragmentTitle(summary: string) {
-  return generatePlainText(FRAGMENT_TITLE_PROMPT, summary);
-}
-
-export async function generateUserFacingResponse(summary: string) {
-  return generatePlainText(RESPONSE_PROMPT, summary);
+export async function generateUserFacingResponse(summary: string): Promise<string> {
+  const { text } = await generateText({
+    model: openai("gpt-5.4"),
+    system: RESPONSE_PROMPT,
+    prompt: summary,
+  });
+  return text.trim();
 }

--- a/src/codegen/runtime.ts
+++ b/src/codegen/runtime.ts
@@ -174,11 +174,16 @@ function createAgentTools(
         question: z.string().describe("The question to ask the user"),
       }),
       execute: async ({ question }) => {
-        // Create a workflow hook — this suspends the step until resumeHook is called
         const hook = createHook<{ answer: string }>();
         emit({ type: "ask_user", question, hookToken: hook.token });
-        // Await the hook — execution pauses here until the user responds via POST /api/generation/[jobId]/respond
-        const response = await hook;
+
+        // Race: user answers vs 5-minute auto-skip timeout
+        const ASK_TIMEOUT_MS = 5 * 60 * 1000;
+        const timeoutPromise = new Promise<{ answer: string }>((resolve) =>
+          setTimeout(() => resolve({ answer: "(no response — continue with your best judgment)" }), ASK_TIMEOUT_MS)
+        );
+
+        const response = await Promise.race([hook, timeoutPromise]);
         return { answer: response.answer };
       },
     }),

--- a/src/codegen/sandbox/e2b-adapter.ts
+++ b/src/codegen/sandbox/e2b-adapter.ts
@@ -1,61 +1,83 @@
 import { Sandbox } from "e2b";
-import { SandboxAdapter, type SandboxFile, type SandboxReadResult } from "./types";
+import type { SandboxAdapter, SandboxFile, SandboxReadResult, CommandResult, DirectoryEntry } from "./types";
 
 const SANDBOX_TIMEOUT = 60_000 * 10 * 3;
 
-async function connectToSandbox(sandboxId: string) {
-  const sandbox = await Sandbox.connect(sandboxId);
-  await sandbox.setTimeout(SANDBOX_TIMEOUT);
-  return sandbox;
-}
-
 class E2BSandboxAdapter implements SandboxAdapter {
+  private _sandbox: Sandbox | null = null;
+
   constructor(public readonly id: string) {}
 
-  async runCommand(command: string) {
-    const buffers = { stdout: "", stderr: "" };
+  private async getSandbox(): Promise<Sandbox> {
+    if (!this._sandbox) {
+      this._sandbox = await Sandbox.connect(this.id);
+      await this._sandbox.setTimeout(SANDBOX_TIMEOUT);
+    }
+    return this._sandbox;
+  }
+
+  async runCommand(command: string): Promise<CommandResult> {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
 
     try {
-      const sandbox = await connectToSandbox(this.id);
+      const sandbox = await this.getSandbox();
       const result = await sandbox.commands.run(command, {
-        onStdout: (data: string) => {
-          buffers.stdout += data;
-        },
-        onStderr: (data: string) => {
-          buffers.stderr += data;
-        },
+        onStdout: (data: string) => { stdout.push(data); },
+        onStderr: (data: string) => { stderr.push(data); },
       });
 
-      return result.stdout;
+      return {
+        stdout: stdout.join(""),
+        stderr: stderr.join(""),
+        exitCode: result.exitCode,
+      };
     } catch (error) {
-      const details = `Command failed: ${error} \nstddout: ${buffers.stdout}\nstderr: ${buffers.stderr}`;
-      console.error(details);
-      return details;
+      return {
+        stdout: stdout.join(""),
+        stderr: stderr.join("") || String(error),
+        exitCode: 1,
+      };
     }
   }
 
-  async writeFiles(files: SandboxFile[]) {
-    const sandbox = await connectToSandbox(this.id);
+  async writeFile(path: string, content: string): Promise<void> {
+    const sandbox = await this.getSandbox();
+    await sandbox.files.write(path, content);
+  }
 
+  async readFile(path: string): Promise<string> {
+    const sandbox = await this.getSandbox();
+    return sandbox.files.read(path);
+  }
+
+  async listDirectory(path: string): Promise<DirectoryEntry[]> {
+    const sandbox = await this.getSandbox();
+    const entries = await sandbox.files.list(path);
+    return entries.map((entry) => ({
+      name: entry.name,
+      path: entry.path,
+      type: entry.type === "dir" ? "dir" : "file",
+    }));
+  }
+
+  async writeFiles(files: SandboxFile[]): Promise<void> {
     for (const file of files) {
-      await sandbox.files.write(file.path, file.content);
+      await this.writeFile(file.path, file.content);
     }
   }
 
   async readFiles(paths: string[]): Promise<SandboxReadResult[]> {
-    const sandbox = await connectToSandbox(this.id);
-    const contents: SandboxReadResult[] = [];
-
+    const results: SandboxReadResult[] = [];
     for (const path of paths) {
-      const content = await sandbox.files.read(path);
-      contents.push({ path, content });
+      const content = await this.readFile(path);
+      results.push({ path, content });
     }
-
-    return contents;
+    return results;
   }
 
-  async getPreviewUrl(port: number) {
-    const sandbox = await connectToSandbox(this.id);
+  async getPreviewUrl(port: number): Promise<string> {
+    const sandbox = await this.getSandbox();
     const host = sandbox.getHost(port);
     return `https://${host}`;
   }
@@ -68,6 +90,5 @@ export async function createE2BSandboxAdapter(template = "nextly-base-dev") {
 }
 
 export async function connectE2BSandboxAdapter(sandboxId: string) {
-  await connectToSandbox(sandboxId);
   return new E2BSandboxAdapter(sandboxId);
 }

--- a/src/codegen/sandbox/types.ts
+++ b/src/codegen/sandbox/types.ts
@@ -8,10 +8,29 @@ export type SandboxReadResult = {
   content: string;
 };
 
+export type CommandResult = {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+export type DirectoryEntry = {
+  name: string;
+  path: string;
+  type: "file" | "dir";
+};
+
 export interface SandboxAdapter {
   readonly id: string;
-  runCommand(command: string): Promise<string>;
+  // Granular file ops
+  writeFile(path: string, content: string): Promise<void>;
+  readFile(path: string): Promise<string>;
+  listDirectory(path: string): Promise<DirectoryEntry[]>;
+  // Batch ops (kept for compat)
   writeFiles(files: SandboxFile[]): Promise<void>;
   readFiles(paths: string[]): Promise<SandboxReadResult[]>;
+  // Command execution — returns structured result
+  runCommand(command: string): Promise<CommandResult>;
+  // Preview
   getPreviewUrl(port: number): Promise<string>;
 }

--- a/src/codegen/stream-events.ts
+++ b/src/codegen/stream-events.ts
@@ -1,0 +1,23 @@
+export type AgentStreamEvent =
+  | { type: "status"; status: "running" | "building" | "fixing" | "waiting_for_user" | "completed" | "failed" }
+  | { type: "tool_start"; tool: string; args: Record<string, unknown> }
+  | { type: "tool_result"; tool: string; result: unknown }
+  | { type: "text_delta"; content: string }
+  | { type: "build_result"; pass: boolean; errors?: string; attempt: number }
+  | { type: "fix_attempt"; attempt: number; maxAttempts: number }
+  | { type: "ask_user"; question: string; hookToken: string }
+  | { type: "done"; summary: string }
+  | { type: "error"; message: string }
+
+export function encodeEvent(event: AgentStreamEvent): string {
+  return "data: " + JSON.stringify(event) + "\n\n";
+}
+
+export function decodeEventLine(line: string): AgentStreamEvent | null {
+  if (!line.startsWith("data: ")) return null;
+  try {
+    return JSON.parse(line.slice(6)) as AgentStreamEvent;
+  } catch {
+    return null;
+  }
+}

--- a/src/hooks/use-generation-stream.ts
+++ b/src/hooks/use-generation-stream.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback } from "react";
+import { decodeEventLine, type AgentStreamEvent } from "@/codegen/stream-events";
+
+export type GenerationStreamState = {
+  events: AgentStreamEvent[];
+  status: "idle" | "connecting" | "streaming" | "done" | "error";
+  currentStatus: string | null;
+  pendingQuestion: { question: string; hookToken: string } | null;
+  error: string | null;
+};
+
+export function useGenerationStream(jobId: string | null) {
+  const [state, setState] = useState<GenerationStreamState>({
+    events: [],
+    status: "idle",
+    currentStatus: null,
+    pendingQuestion: null,
+    error: null,
+  });
+
+  const abortRef = useRef<AbortController | null>(null);
+  const startIndexRef = useRef<number | undefined>(undefined);
+
+  const connect = useCallback(
+    (id: string) => {
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      setState((prev) => ({ ...prev, status: "connecting", events: [], error: null }));
+
+      const url = startIndexRef.current !== undefined
+        ? `/api/generation/${id}/stream?startIndex=${startIndexRef.current}`
+        : `/api/generation/${id}/stream`;
+
+      (async () => {
+        try {
+          const response = await fetch(url, { signal: controller.signal });
+          if (!response.ok || !response.body) {
+            throw new Error("Stream failed: " + response.status);
+          }
+
+          setState((prev) => ({ ...prev, status: "streaming" }));
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = "";
+          let chunkIndex = 0;
+
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            chunkIndex++;
+
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
+
+            for (const line of lines) {
+              const event = decodeEventLine(line);
+              if (!event) continue;
+
+              startIndexRef.current = chunkIndex;
+
+              setState((prev) => {
+                const next: GenerationStreamState = {
+                  ...prev,
+                  events: [...prev.events, event],
+                };
+
+                if (event.type === "status") {
+                  next.currentStatus = event.status;
+                } else if (event.type === "ask_user") {
+                  next.pendingQuestion = { question: event.question, hookToken: event.hookToken };
+                  next.currentStatus = "waiting_for_user";
+                } else if (event.type === "done" || event.type === "error") {
+                  next.status = "done";
+                  next.pendingQuestion = null;
+                }
+
+                return next;
+              });
+            }
+          }
+
+          setState((prev) => ({ ...prev, status: "done" }));
+        } catch (err) {
+          if ((err as Error).name === "AbortError") return;
+          // Attempt reconnect on network failure
+          setState((prev) => ({
+            ...prev,
+            status: "error",
+            error: (err as Error).message,
+          }));
+        }
+      })();
+    },
+    [],
+  );
+
+  const respond = useCallback(async (jobId: string, hookToken: string, answer: string) => {
+    setState((prev) => ({ ...prev, pendingQuestion: null }));
+    await fetch(`/api/generation/${jobId}/respond`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ hookToken, answer }),
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!jobId) return;
+    startIndexRef.current = undefined;
+    connect(jobId);
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [jobId, connect]);
+
+  return { state, respond };
+}

--- a/src/hooks/use-generation-stream.ts
+++ b/src/hooks/use-generation-stream.ts
@@ -11,6 +11,9 @@ export type GenerationStreamState = {
   error: string | null;
 };
 
+const MAX_RECONNECT_ATTEMPTS = 5;
+const RECONNECT_DELAY_MS = 2000;
+
 export function useGenerationStream(jobId: string | null) {
   const [state, setState] = useState<GenerationStreamState>({
     events: [],
@@ -22,84 +25,96 @@ export function useGenerationStream(jobId: string | null) {
 
   const abortRef = useRef<AbortController | null>(null);
   const startIndexRef = useRef<number | undefined>(undefined);
+  const reconnectAttemptsRef = useRef(0);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const connect = useCallback(
-    (id: string) => {
-      abortRef.current?.abort();
-      const controller = new AbortController();
-      abortRef.current = controller;
+  const connect = useCallback((id: string, isReconnect = false) => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
 
+    if (!isReconnect) {
       setState((prev) => ({ ...prev, status: "connecting", events: [], error: null }));
+    }
 
-      const url = startIndexRef.current !== undefined
-        ? `/api/generation/${id}/stream?startIndex=${startIndexRef.current}`
-        : `/api/generation/${id}/stream`;
+    const url = startIndexRef.current !== undefined
+      ? `/api/generation/${id}/stream?startIndex=${startIndexRef.current}`
+      : `/api/generation/${id}/stream`;
 
-      (async () => {
-        try {
-          const response = await fetch(url, { signal: controller.signal });
-          if (!response.ok || !response.body) {
-            throw new Error("Stream failed: " + response.status);
+    (async () => {
+      try {
+        const response = await fetch(url, { signal: controller.signal });
+        if (!response.ok || !response.body) {
+          throw new Error("Stream request failed: " + response.status);
+        }
+
+        reconnectAttemptsRef.current = 0;
+        setState((prev) => ({ ...prev, status: "streaming", error: null }));
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let chunkIndex = startIndexRef.current ?? 0;
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          chunkIndex++;
+          startIndexRef.current = chunkIndex;
+
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            const event = decodeEventLine(line);
+            if (!event) continue;
+
+            setState((prev) => {
+              const next: GenerationStreamState = {
+                ...prev,
+                events: [...prev.events, event],
+              };
+
+              if (event.type === "status") {
+                next.currentStatus = event.status;
+              } else if (event.type === "ask_user") {
+                next.pendingQuestion = { question: event.question, hookToken: event.hookToken };
+                next.currentStatus = "waiting_for_user";
+              } else if (event.type === "done" || event.type === "error") {
+                next.status = "done";
+                next.pendingQuestion = null;
+              }
+
+              return next;
+            });
           }
+        }
 
-          setState((prev) => ({ ...prev, status: "streaming" }));
+        setState((prev) => {
+          if (prev.status !== "done") return { ...prev, status: "done" };
+          return prev;
+        });
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
 
-          const reader = response.body.getReader();
-          const decoder = new TextDecoder();
-          let buffer = "";
-          let chunkIndex = 0;
-
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-
-            buffer += decoder.decode(value, { stream: true });
-            chunkIndex++;
-
-            const lines = buffer.split("\n");
-            buffer = lines.pop() ?? "";
-
-            for (const line of lines) {
-              const event = decodeEventLine(line);
-              if (!event) continue;
-
-              startIndexRef.current = chunkIndex;
-
-              setState((prev) => {
-                const next: GenerationStreamState = {
-                  ...prev,
-                  events: [...prev.events, event],
-                };
-
-                if (event.type === "status") {
-                  next.currentStatus = event.status;
-                } else if (event.type === "ask_user") {
-                  next.pendingQuestion = { question: event.question, hookToken: event.hookToken };
-                  next.currentStatus = "waiting_for_user";
-                } else if (event.type === "done" || event.type === "error") {
-                  next.status = "done";
-                  next.pendingQuestion = null;
-                }
-
-                return next;
-              });
-            }
-          }
-
-          setState((prev) => ({ ...prev, status: "done" }));
-        } catch (err) {
-          if ((err as Error).name === "AbortError") return;
-          // Attempt reconnect on network failure
+        // Auto-reconnect on transient network errors
+        if (reconnectAttemptsRef.current < MAX_RECONNECT_ATTEMPTS) {
+          reconnectAttemptsRef.current++;
+          const delay = RECONNECT_DELAY_MS * reconnectAttemptsRef.current;
+          setState((prev) => ({ ...prev, error: `Connection lost, reconnecting... (${reconnectAttemptsRef.current}/${MAX_RECONNECT_ATTEMPTS})` }));
+          reconnectTimerRef.current = setTimeout(() => connect(id, true), delay);
+        } else {
           setState((prev) => ({
             ...prev,
             status: "error",
-            error: (err as Error).message,
+            error: "Connection failed after " + MAX_RECONNECT_ATTEMPTS + " attempts. " + (err as Error).message,
           }));
         }
-      })();
-    },
-    [],
-  );
+      }
+    })();
+  }, []);
 
   const respond = useCallback(async (jobId: string, hookToken: string, answer: string) => {
     setState((prev) => ({ ...prev, pendingQuestion: null }));
@@ -110,14 +125,23 @@ export function useGenerationStream(jobId: string | null) {
     });
   }, []);
 
+  const cancel = useCallback(async (jobId: string) => {
+    abortRef.current?.abort();
+    if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+    setState((prev) => ({ ...prev, status: "done", currentStatus: "failed", pendingQuestion: null }));
+    await fetch(`/api/generation/${jobId}/cancel`, { method: "POST" });
+  }, []);
+
   useEffect(() => {
     if (!jobId) return;
     startIndexRef.current = undefined;
+    reconnectAttemptsRef.current = 0;
     connect(jobId);
     return () => {
       abortRef.current?.abort();
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
     };
   }, [jobId, connect]);
 
-  return { state, respond };
+  return { state, respond, cancel };
 }

--- a/src/lib/generation-jobs.ts
+++ b/src/lib/generation-jobs.ts
@@ -74,3 +74,16 @@ export async function attachGenerationJobWorkflowRun(jobId: string, workflowRunI
     },
   });
 }
+
+export async function getGenerationJobById(jobId: string) {
+  return prisma.generationJob.findUnique({
+    where: { id: jobId },
+    select: {
+      id: true,
+      status: true,
+      workflowRunId: true,
+      projectId: true,
+      organizationId: true,
+    },
+  });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,7 @@ const publicRoutes = [
   "/pricing",
   "/api/trpc",
   "/api/auth",
+  "/api/generation",
   "/.well-known/workflow",
   "/terms",
   "/privacy",

--- a/src/modules/messages/server/procedures.ts
+++ b/src/modules/messages/server/procedures.ts
@@ -112,7 +112,7 @@ export const messagesRouter = createTRPCRouter({
         throw error;
       }
 
-      return createdMessage;
+      return { ...createdMessage, generationJobId: generationJob.id };
     }),
 });
 

--- a/src/modules/projects/ui/components/generation-stream.tsx
+++ b/src/modules/projects/ui/components/generation-stream.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import Image from "next/image";
+import { useRef, useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Loader2, CheckCircle2, XCircle, Terminal, FileText, Search, FolderOpen, Package, AlertTriangle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { AgentStreamEvent } from "@/codegen/stream-events";
+import type { GenerationStreamState } from "@/hooks/use-generation-stream";
+
+interface Props {
+  state: GenerationStreamState;
+  jobId: string;
+  onRespond: (hookToken: string, answer: string) => void;
+}
+
+const TOOL_ICONS: Record<string, React.ReactNode> = {
+  writeFile: <FileText className="h-3.5 w-3.5" />,
+  readFile: <FileText className="h-3.5 w-3.5" />,
+  createOrUpdateFiles: <FileText className="h-3.5 w-3.5" />,
+  terminal: <Terminal className="h-3.5 w-3.5" />,
+  installPackage: <Package className="h-3.5 w-3.5" />,
+  searchFiles: <Search className="h-3.5 w-3.5" />,
+  listDirectory: <FolderOpen className="h-3.5 w-3.5" />,
+};
+
+function statusLabel(status: string | null): string {
+  switch (status) {
+    case "running": return "Building your app";
+    case "building": return "Verifying build";
+    case "fixing": return "Fixing build errors";
+    case "waiting_for_user": return "Waiting for your answer";
+    case "completed": return "Done";
+    case "failed": return "Failed";
+    default: return "Generating";
+  }
+}
+
+function ToolCallRow({ event }: { event: AgentStreamEvent & { type: "tool_start" } }) {
+  const icon = TOOL_ICONS[event.tool] ?? <Terminal className="h-3.5 w-3.5" />;
+  const label = event.tool === "writeFile" && typeof event.args.path === "string"
+    ? event.args.path
+    : event.tool === "terminal" && typeof event.args.command === "string"
+    ? event.args.command.slice(0, 60)
+    : event.tool === "installPackage" && Array.isArray(event.args.packages)
+    ? (event.args.packages as string[]).join(", ")
+    : event.tool;
+
+  return (
+    <div className="flex items-center gap-2 py-1 px-2 rounded-md bg-muted/40 text-xs text-muted-foreground font-mono">
+      <span className="text-primary/70">{icon}</span>
+      <span className="truncate">{label}</span>
+    </div>
+  );
+}
+
+function BuildResultRow({ event }: { event: AgentStreamEvent & { type: "build_result" } }) {
+  return (
+    <div className={cn(
+      "flex items-start gap-2 py-1.5 px-2 rounded-md text-xs font-mono",
+      event.pass
+        ? "bg-green-500/10 text-green-700 dark:text-green-400"
+        : "bg-red-500/10 text-red-700 dark:text-red-400"
+    )}>
+      {event.pass
+        ? <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+        : <XCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />}
+      <span>
+        {event.pass ? "Build passed" : "Build failed (attempt " + event.attempt + ")"}
+        {!event.pass && event.errors && (
+          <span className="block mt-1 text-[10px] opacity-70 whitespace-pre-wrap">{event.errors.slice(0, 300)}{event.errors.length > 300 ? "…" : ""}</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function AskUserInput({ question, onSubmit }: { question: string; onSubmit: (answer: string) => void }) {
+  const [value, setValue] = useState("");
+  return (
+    <div className="mt-2 space-y-2">
+      <p className="text-sm font-medium">{question}</p>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 h-8 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+          placeholder="Your answer..."
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && value.trim()) {
+              onSubmit(value.trim());
+              setValue("");
+            }
+          }}
+          autoFocus
+        />
+        <Button
+          size="sm"
+          disabled={!value.trim()}
+          onClick={() => { onSubmit(value.trim()); setValue(""); }}
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function GenerationStream({ state, jobId, onRespond }: Props) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Keep scroll at bottom as events come in
+  useEffect(() => {
+    scrollRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [state.events.length]);
+
+  const toolStartEvents = state.events.filter(
+    (e): e is AgentStreamEvent & { type: "tool_start" } => e.type === "tool_start"
+  );
+  const buildEvents = state.events.filter(
+    (e): e is AgentStreamEvent & { type: "build_result" } => e.type === "build_result"
+  );
+  const fixEvents = state.events.filter(
+    (e): e is AgentStreamEvent & { type: "fix_attempt" } => e.type === "fix_attempt"
+  );
+  const isStreaming = state.status === "streaming" || state.status === "connecting";
+
+  return (
+    <div className="flex flex-col group px-4 pb-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div className="relative">
+            <div className="w-9 h-9 rounded-full bg-gradient-to-br from-muted/80 to-muted dark:from-muted/60 dark:to-muted/80 flex items-center justify-center border-2 border-border shadow-md">
+              <Image src="/logo.svg" alt="Nextly AI" width={20} height={20} />
+            </div>
+            {isStreaming && (
+              <div className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 bg-yellow-500 rounded-full border-2 border-background animate-pulse" />
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-base font-bold">Nextly AI</span>
+            <div className={cn(
+              "flex items-center gap-1.5 px-2.5 py-1 border rounded-full",
+              isStreaming
+                ? "bg-yellow-500/8 border-yellow-500/20 dark:border-yellow-500/30"
+                : "bg-muted/40 border-border"
+            )}>
+              {isStreaming
+                ? <Loader2 className="h-3.5 w-3.5 text-yellow-600 animate-spin" />
+                : state.status === "done"
+                ? <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
+                : <AlertTriangle className="h-3.5 w-3.5 text-red-500" />}
+              <span className={cn(
+                "text-xs font-medium",
+                isStreaming ? "text-yellow-700 dark:text-yellow-400" : "text-muted-foreground"
+              )}>
+                {statusLabel(state.currentStatus)}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Stream content */}
+      <div className="pl-12 flex flex-col gap-2">
+        <Card className={cn(
+          "relative border-2 rounded-2xl p-4 shadow-sm",
+          "border-yellow-500/25 dark:border-yellow-500/35 bg-yellow-500/3 dark:bg-yellow-500/8"
+        )}>
+          <div className="space-y-1.5 max-h-64 overflow-y-auto pr-1">
+            {toolStartEvents.length === 0 && fixEvents.length === 0 && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                <span>Starting agent...</span>
+              </div>
+            )}
+            {toolStartEvents.map((e, i) => (
+              <ToolCallRow key={i} event={e} />
+            ))}
+            {fixEvents.map((e, i) => (
+              <div key={i} className="flex items-center gap-2 text-xs text-orange-600 dark:text-orange-400 font-medium px-2 py-1">
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                Fix attempt {e.attempt} of {e.maxAttempts}
+              </div>
+            ))}
+            {buildEvents.map((e, i) => (
+              <BuildResultRow key={i} event={e} />
+            ))}
+          </div>
+
+          {/* Ask user */}
+          {state.pendingQuestion && (
+            <AskUserInput
+              question={state.pendingQuestion.question}
+              onSubmit={(answer) => onRespond(state.pendingQuestion!.hookToken, answer)}
+            />
+          )}
+
+          <div ref={scrollRef} />
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/projects/ui/components/generation-stream.tsx
+++ b/src/modules/projects/ui/components/generation-stream.tsx
@@ -1,21 +1,56 @@
 "use client";
 
 import Image from "next/image";
-import { useRef, useEffect, useState } from "react";
+import { Component, type ReactNode, useRef, useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Loader2, CheckCircle2, XCircle, Terminal, FileText, Search, FolderOpen, Package, AlertTriangle } from "lucide-react";
+import { Loader2, CheckCircle2, XCircle, Terminal, FileText, Search, FolderOpen, Package, AlertTriangle, StopCircle, WifiOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AgentStreamEvent } from "@/codegen/stream-events";
 import type { GenerationStreamState } from "@/hooks/use-generation-stream";
+
+// ─── Error Boundary ──────────────────────────────────────────────────────────
+
+interface ErrorBoundaryProps { children: ReactNode; fallback?: ReactNode }
+interface ErrorBoundaryState { hasError: boolean; message: string }
+
+export class GenerationStreamErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, message: "" };
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    return { hasError: true, message: error instanceof Error ? error.message : "Unknown error" };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div className="px-4 pb-6">
+          <div className="pl-12">
+            <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-red-500/10 border border-red-500/20 text-sm text-red-600 dark:text-red-400">
+              <XCircle className="h-4 w-4 shrink-0" />
+              Stream error: {this.state.message}
+            </div>
+          </div>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
 
 interface Props {
   state: GenerationStreamState;
   jobId: string;
   onRespond: (hookToken: string, answer: string) => void;
+  onCancel: () => void;
 }
 
-const TOOL_ICONS: Record<string, React.ReactNode> = {
+const TOOL_ICONS: Record<string, ReactNode> = {
   writeFile: <FileText className="h-3.5 w-3.5" />,
   readFile: <FileText className="h-3.5 w-3.5" />,
   createOrUpdateFiles: <FileText className="h-3.5 w-3.5" />,
@@ -39,13 +74,14 @@ function statusLabel(status: string | null): string {
 
 function ToolCallRow({ event }: { event: AgentStreamEvent & { type: "tool_start" } }) {
   const icon = TOOL_ICONS[event.tool] ?? <Terminal className="h-3.5 w-3.5" />;
-  const label = event.tool === "writeFile" && typeof event.args.path === "string"
-    ? event.args.path
-    : event.tool === "terminal" && typeof event.args.command === "string"
-    ? event.args.command.slice(0, 60)
-    : event.tool === "installPackage" && Array.isArray(event.args.packages)
-    ? (event.args.packages as string[]).join(", ")
-    : event.tool;
+  const label =
+    event.tool === "writeFile" && typeof event.args.path === "string"
+      ? event.args.path
+      : event.tool === "terminal" && typeof event.args.command === "string"
+      ? event.args.command.slice(0, 60)
+      : event.tool === "installPackage" && Array.isArray(event.args.packages)
+      ? (event.args.packages as string[]).join(", ")
+      : event.tool;
 
   return (
     <div className="flex items-center gap-2 py-1 px-2 rounded-md bg-muted/40 text-xs text-muted-foreground font-mono">
@@ -61,7 +97,7 @@ function BuildResultRow({ event }: { event: AgentStreamEvent & { type: "build_re
       "flex items-start gap-2 py-1.5 px-2 rounded-md text-xs font-mono",
       event.pass
         ? "bg-green-500/10 text-green-700 dark:text-green-400"
-        : "bg-red-500/10 text-red-700 dark:text-red-400"
+        : "bg-red-500/10 text-red-700 dark:text-red-400",
     )}>
       {event.pass
         ? <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 shrink-0" />
@@ -69,7 +105,9 @@ function BuildResultRow({ event }: { event: AgentStreamEvent & { type: "build_re
       <span>
         {event.pass ? "Build passed" : "Build failed (attempt " + event.attempt + ")"}
         {!event.pass && event.errors && (
-          <span className="block mt-1 text-[10px] opacity-70 whitespace-pre-wrap">{event.errors.slice(0, 300)}{event.errors.length > 300 ? "…" : ""}</span>
+          <span className="block mt-1 text-[10px] opacity-70 whitespace-pre-wrap">
+            {event.errors.slice(0, 300)}{event.errors.length > 300 ? "…" : ""}
+          </span>
         )}
       </span>
     </div>
@@ -78,9 +116,24 @@ function BuildResultRow({ event }: { event: AgentStreamEvent & { type: "build_re
 
 function AskUserInput({ question, onSubmit }: { question: string; onSubmit: (answer: string) => void }) {
   const [value, setValue] = useState("");
+  const [secondsLeft, setSecondsLeft] = useState(300);
+
+  useEffect(() => {
+    const t = setInterval(() => setSecondsLeft((s) => Math.max(0, s - 1)), 1000);
+    return () => clearInterval(t);
+  }, []);
+
+  const minutes = Math.floor(secondsLeft / 60);
+  const seconds = secondsLeft % 60;
+
   return (
-    <div className="mt-2 space-y-2">
-      <p className="text-sm font-medium">{question}</p>
+    <div className="mt-3 space-y-2 border-t border-border/50 pt-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium">{question}</p>
+        <span className="text-[10px] text-muted-foreground tabular-nums">
+          {minutes}:{seconds.toString().padStart(2, "0")}
+        </span>
+      </div>
       <div className="flex gap-2">
         <input
           className="flex-1 h-8 rounded-md border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
@@ -107,24 +160,28 @@ function AskUserInput({ question, onSubmit }: { question: string; onSubmit: (ans
   );
 }
 
-export function GenerationStream({ state, jobId, onRespond }: Props) {
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function GenerationStream({ state, jobId, onRespond, onCancel }: Props) {
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Keep scroll at bottom as events come in
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [state.events.length]);
 
   const toolStartEvents = state.events.filter(
-    (e): e is AgentStreamEvent & { type: "tool_start" } => e.type === "tool_start"
+    (e): e is AgentStreamEvent & { type: "tool_start" } => e.type === "tool_start",
   );
   const buildEvents = state.events.filter(
-    (e): e is AgentStreamEvent & { type: "build_result" } => e.type === "build_result"
+    (e): e is AgentStreamEvent & { type: "build_result" } => e.type === "build_result",
   );
   const fixEvents = state.events.filter(
-    (e): e is AgentStreamEvent & { type: "fix_attempt" } => e.type === "fix_attempt"
+    (e): e is AgentStreamEvent & { type: "fix_attempt" } => e.type === "fix_attempt",
   );
+
   const isStreaming = state.status === "streaming" || state.status === "connecting";
+  const isReconnecting = isStreaming && state.error !== null;
+  const [cancelling, setCancelling] = useState(false);
 
   return (
     <div className="flex flex-col group px-4 pb-6">
@@ -135,39 +192,66 @@ export function GenerationStream({ state, jobId, onRespond }: Props) {
             <div className="w-9 h-9 rounded-full bg-gradient-to-br from-muted/80 to-muted dark:from-muted/60 dark:to-muted/80 flex items-center justify-center border-2 border-border shadow-md">
               <Image src="/logo.svg" alt="Nextly AI" width={20} height={20} />
             </div>
-            {isStreaming && (
+            {isStreaming && !isReconnecting && (
               <div className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 bg-yellow-500 rounded-full border-2 border-background animate-pulse" />
+            )}
+            {isReconnecting && (
+              <div className="absolute -bottom-0.5 -right-0.5 w-3.5 h-3.5 bg-orange-500 rounded-full border-2 border-background animate-pulse" />
             )}
           </div>
           <div className="flex items-center gap-3">
             <span className="text-base font-bold">Nextly AI</span>
             <div className={cn(
               "flex items-center gap-1.5 px-2.5 py-1 border rounded-full",
-              isStreaming
+              isReconnecting
+                ? "bg-orange-500/10 border-orange-500/20"
+                : isStreaming
                 ? "bg-yellow-500/8 border-yellow-500/20 dark:border-yellow-500/30"
-                : "bg-muted/40 border-border"
+                : "bg-muted/40 border-border",
             )}>
-              {isStreaming
+              {isReconnecting
+                ? <WifiOff className="h-3.5 w-3.5 text-orange-500" />
+                : isStreaming
                 ? <Loader2 className="h-3.5 w-3.5 text-yellow-600 animate-spin" />
-                : state.status === "done"
+                : state.status === "done" && state.currentStatus !== "failed"
                 ? <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
                 : <AlertTriangle className="h-3.5 w-3.5 text-red-500" />}
               <span className={cn(
                 "text-xs font-medium",
-                isStreaming ? "text-yellow-700 dark:text-yellow-400" : "text-muted-foreground"
+                isReconnecting ? "text-orange-600" :
+                isStreaming ? "text-yellow-700 dark:text-yellow-400" : "text-muted-foreground",
               )}>
-                {statusLabel(state.currentStatus)}
+                {isReconnecting ? state.error : statusLabel(state.currentStatus)}
               </span>
             </div>
           </div>
         </div>
+
+        {/* Cancel button */}
+        {isStreaming && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2 text-xs text-muted-foreground hover:text-destructive gap-1"
+            disabled={cancelling}
+            onClick={async () => {
+              setCancelling(true);
+              await onCancel();
+            }}
+          >
+            <StopCircle className="h-3.5 w-3.5" />
+            {cancelling ? "Stopping…" : "Stop"}
+          </Button>
+        )}
       </div>
 
       {/* Stream content */}
       <div className="pl-12 flex flex-col gap-2">
         <Card className={cn(
           "relative border-2 rounded-2xl p-4 shadow-sm",
-          "border-yellow-500/25 dark:border-yellow-500/35 bg-yellow-500/3 dark:bg-yellow-500/8"
+          state.currentStatus === "failed"
+            ? "border-red-500/25 bg-red-500/3"
+            : "border-yellow-500/25 dark:border-yellow-500/35 bg-yellow-500/3 dark:bg-yellow-500/8",
         )}>
           <div className="space-y-1.5 max-h-64 overflow-y-auto pr-1">
             {toolStartEvents.length === 0 && fixEvents.length === 0 && (
@@ -176,21 +260,16 @@ export function GenerationStream({ state, jobId, onRespond }: Props) {
                 <span>Starting agent...</span>
               </div>
             )}
-            {toolStartEvents.map((e, i) => (
-              <ToolCallRow key={i} event={e} />
-            ))}
+            {toolStartEvents.map((e, i) => <ToolCallRow key={i} event={e} />)}
             {fixEvents.map((e, i) => (
               <div key={i} className="flex items-center gap-2 text-xs text-orange-600 dark:text-orange-400 font-medium px-2 py-1">
                 <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
                 Fix attempt {e.attempt} of {e.maxAttempts}
               </div>
             ))}
-            {buildEvents.map((e, i) => (
-              <BuildResultRow key={i} event={e} />
-            ))}
+            {buildEvents.map((e, i) => <BuildResultRow key={i} event={e} />)}
           </div>
 
-          {/* Ask user */}
           {state.pendingQuestion && (
             <AskUserInput
               question={state.pendingQuestion.question}

--- a/src/modules/projects/ui/components/message-form.tsx
+++ b/src/modules/projects/ui/components/message-form.tsx
@@ -17,6 +17,7 @@ import { useSession } from "@/lib/auth-client";
 
 interface Props {
   projectId: string;
+  onJobCreated?: (jobId: string) => void;
 }
 
 const GlassEffect: React.FC<{ children: React.ReactNode; className?: string }> = ({
@@ -46,7 +47,7 @@ const formSchema = z.object({
     .max(1000, { message: "Message cannot be longer than 1000 characters" }),
 });
 
-export const MessageForm = ({ projectId }: Props) => {
+export const MessageForm = ({ projectId, onJobCreated }: Props) => {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const { data: session } = useSession();
@@ -61,13 +62,16 @@ export const MessageForm = ({ projectId }: Props) => {
 
   const createMessage = useMutation(
     trpc.messages.create.mutationOptions({
-      onSuccess: () => {
+      onSuccess: (data) => {
         form.reset();
         queryClient.invalidateQueries(trpc.messages.getMany.queryOptions({ projectId }));
         queryClient.invalidateQueries(
           trpc.generationJobs.latestForProject.queryOptions({ projectId })
         );
         queryClient.invalidateQueries(trpc.usage.status.queryOptions());
+        if (data.generationJobId) {
+          onJobCreated?.(data.generationJobId);
+        }
       },
       onError: () => toast.error("Failed to create message"),
     })

--- a/src/modules/projects/ui/components/messages-container.tsx
+++ b/src/modules/projects/ui/components/messages-container.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery, useSuspenseQuery, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "@/trpc/client";
 import { MessageCard } from "./message-card";
 import { MessageForm } from "./message-form";
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useState } from "react";
 import type { Fragment } from "@/lib/types";
 import { MessageLoading } from "./message-loading";
+import { GenerationStream } from "./generation-stream";
+import { useGenerationStream } from "@/hooks/use-generation-stream";
 
 interface Props {
   projectId: string;
@@ -21,29 +23,52 @@ export const MessagesContainer = ({
 }: Props) => {
   const bottomRef = useRef<HTMLDivElement>(null);
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
   const lastAssistantMessageIdRef = useRef<string | null>(null);
+
+  // The active job ID we're streaming — set when a new generation starts
+  const [streamingJobId, setStreamingJobId] = useState<string | null>(null);
 
   const { data: messages } = useSuspenseQuery(
     trpc.messages.getMany.queryOptions(
-      {
-        projectId,
-      },
-      {
-        refetchInterval: 5000,
-      }
+      { projectId },
+      { refetchInterval: 5000 },
     )
   );
 
   const { data: latestGenerationJob } = useQuery(
     trpc.generationJobs.latestForProject.queryOptions(
-      {
-        projectId,
-      },
-      {
-        refetchInterval: 5000,
-      },
+      { projectId },
+      { refetchInterval: 5000 },
     ),
   );
+
+  // When a job becomes active, start streaming it
+  useEffect(() => {
+    if (
+      latestGenerationJob?.id &&
+      (latestGenerationJob.status === "QUEUED" || latestGenerationJob.status === "RUNNING") &&
+      latestGenerationJob.id !== streamingJobId
+    ) {
+      setStreamingJobId(latestGenerationJob.id);
+    }
+  }, [latestGenerationJob, streamingJobId]);
+
+  // Connect to the stream for the active job
+  const { state: streamState, respond } = useGenerationStream(streamingJobId);
+
+  // When stream finishes, invalidate queries to load the final persisted message
+  useEffect(() => {
+    if (streamState.status === "done") {
+      queryClient.invalidateQueries(trpc.messages.getMany.queryOptions({ projectId }));
+      queryClient.invalidateQueries(
+        trpc.generationJobs.latestForProject.queryOptions({ projectId })
+      );
+      // Clear the streaming job ID after a short delay so the UI transitions cleanly
+      const t = setTimeout(() => setStreamingJobId(null), 2000);
+      return () => clearTimeout(t);
+    }
+  }, [streamState.status, queryClient, trpc, projectId]);
 
   // Auto-set active fragment from last assistant message
   useEffect(() => {
@@ -59,14 +84,18 @@ export const MessagesContainer = ({
     }
   }, [messages, setActiveFragment]);
 
-  // Scroll to bottom on new messages
+  // Scroll to bottom on new messages or stream events
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages?.length]);
+  }, [messages?.length, streamState.events.length]);
 
   const isGenerating =
     latestGenerationJob?.status === "QUEUED" ||
     latestGenerationJob?.status === "RUNNING";
+
+  const isStreaming =
+    streamingJobId !== null &&
+    (streamState.status === "connecting" || streamState.status === "streaming");
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
@@ -74,26 +103,39 @@ export const MessagesContainer = ({
         {messages?.map((message) => (
           <MessageCard
             key={message.id}
-            content={message.content} // full content of message
+            content={message.content}
             role={message.role}
-            fragment={message.fragment} // fragment object
+            fragment={message.fragment}
             createdAt={message.createdAt}
-            isActiveFragment={
-              activeFragment?.id === message.fragment?.id
-            }
+            isActiveFragment={activeFragment?.id === message.fragment?.id}
             onFragmentClick={() =>
               message.fragment && setActiveFragment(message.fragment)
             }
             type={message.type}
           />
         ))}
-        {isGenerating && <MessageLoading />}
+
+        {/* Show real-time stream when available */}
+        {isStreaming && streamingJobId && (
+          <GenerationStream
+            state={streamState}
+            jobId={streamingJobId}
+            onRespond={(hookToken, answer) => respond(streamingJobId, hookToken, answer)}
+          />
+        )}
+
+        {/* Fallback: plain loading state when job is active but stream not connected yet */}
+        {isGenerating && !isStreaming && <MessageLoading />}
+
         <div ref={bottomRef} />
       </div>
 
       <div className="relative p-3 pt-1">
         <div className="absolute top-6 left-0 right-0 h-6 bg-gradient-to-b from-transparent to-background/70 pointer-events-none" />
-        <MessageForm projectId={projectId} />
+        <MessageForm
+          projectId={projectId}
+          onJobCreated={(jobId) => setStreamingJobId(jobId)}
+        />
       </div>
     </div>
   );

--- a/src/modules/projects/ui/components/messages-container.tsx
+++ b/src/modules/projects/ui/components/messages-container.tsx
@@ -7,7 +7,7 @@ import { MessageForm } from "./message-form";
 import { useRef, useEffect, useState } from "react";
 import type { Fragment } from "@/lib/types";
 import { MessageLoading } from "./message-loading";
-import { GenerationStream } from "./generation-stream";
+import { GenerationStream, GenerationStreamErrorBoundary } from "./generation-stream";
 import { useGenerationStream } from "@/hooks/use-generation-stream";
 
 interface Props {
@@ -55,7 +55,7 @@ export const MessagesContainer = ({
   }, [latestGenerationJob, streamingJobId]);
 
   // Connect to the stream for the active job
-  const { state: streamState, respond } = useGenerationStream(streamingJobId);
+  const { state: streamState, respond, cancel } = useGenerationStream(streamingJobId);
 
   // When stream finishes, invalidate queries to load the final persisted message
   useEffect(() => {
@@ -117,11 +117,14 @@ export const MessagesContainer = ({
 
         {/* Show real-time stream when available */}
         {isStreaming && streamingJobId && (
-          <GenerationStream
-            state={streamState}
-            jobId={streamingJobId}
-            onRespond={(hookToken, answer) => respond(streamingJobId, hookToken, answer)}
-          />
+          <GenerationStreamErrorBoundary>
+            <GenerationStream
+              state={streamState}
+              jobId={streamingJobId}
+              onRespond={(hookToken, answer) => respond(streamingJobId, hookToken, answer)}
+              onCancel={() => cancel(streamingJobId)}
+            />
+          </GenerationStreamErrorBoundary>
         )}
 
         {/* Fallback: plain loading state when job is active but stream not connected yet */}

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -18,118 +18,69 @@ The title should be:
 Only return the raw title.
 `
 export const PROMPT = `
-You are a senior software engineer working in a sandboxed Next.js 15.3.3 environment.
+You are an autonomous coding agent working inside a sandboxed Next.js 15.3.3 environment. You have full access to the file system and can run commands.
 
-Environment:
-- Writable file system via createOrUpdateFiles
-- Command execution via terminal (use "npm install <package> --yes")
-- Read files via readFiles
-- Do not modify package.json or lock files directly — install packages using the terminal only
-- Main file: app/page.tsx
-- All Shadcn components are pre-installed and imported from "@/components/ui/*"
-- Tailwind CSS and PostCSS are preconfigured
-- layout.tsx is already defined and wraps all routes — do not include <html>, <body>, or top-level layout
-- You MUST NOT create or modify any .css, .scss, or .sass files — styling must be done strictly using Tailwind CSS classes
-- Important: The @ symbol is an alias used only for imports (e.g. "@/components/ui/button")
-- When using readFiles or accessing the file system, you MUST use the actual path (e.g. "/home/user/components/ui/button.tsx")
-- You are already inside /home/user.
-- All CREATE OR UPDATE file paths must be relative (e.g., "app/page.tsx", "lib/utils.ts").
-- NEVER use absolute paths like "/home/user/..." or "/home/user/app/...".
-- NEVER include "/home/user" in any file path — this will cause critical errors.
-- Never use "@" inside readFiles or other file system operations — it will fail
+## Available Tools
 
-File Safety Rules:
-- ALWAYS add "use client" to the TOP, THE FIRST LINE of app/page.tsx and any other relevant files which use browser APIs or react hooks
+- **writeFile(path, content)** — Write a single file. Use relative paths (e.g. “app/page.tsx”).
+- **readFile(path)** — Read a file. Use absolute paths (e.g. “/home/user/app/page.tsx”).
+- **listDirectory(path)** — List files in a directory. Use absolute paths.
+- **searchFiles(pattern, path?)** — Search text across source files (grep).
+- **terminal(command)** — Run any shell command except dev/build/start scripts.
+- **installPackage(packages[])** — Install npm packages before importing them.
+- **createOrUpdateFiles(files[])** — Write multiple files at once (alternative to writeFile).
 
-Runtime Execution (Strict Rules):
-- The development server is already running on port 3000 with hot reload enabled.
-- You MUST NEVER run commands like:
-  - npm run dev
-  - npm run build
-  - npm run start
-  - next dev
-  - next build
-  - next start
-- These commands will cause unexpected behavior or unnecessary terminal output.
-- Do not attempt to start or restart the app — it is already running and will hot reload when files change.
-- Any attempt to run dev/build/start scripts will be considered a critical error.
+## Environment
 
-Instructions:
-1. Maximize Feature Completeness: Implement all features with realistic, production-quality detail. Avoid placeholders or simplistic stubs. Every component or page should be fully functional and polished.
-   - Example: If building a form or interactive component, include proper state handling, validation, and event logic (and add "use client"; at the top if using React hooks or browser APIs in a component). Do not respond with "TODO" or leave code incomplete. Aim for a finished feature that could be shipped to end-users.
+- Working directory: /home/user
+- The development server is ALREADY running on port 3000 with hot reload.
+- All Shadcn UI components are pre-installed at /home/user/components/ui/*
+- Tailwind CSS v4 and PostCSS are preconfigured.
+- layout.tsx wraps all routes — do NOT include <html>, <body>, or top-level layout elements.
+- Main entry point: app/page.tsx
 
-2. Use Tools for Dependencies (No Assumptions): Always use the terminal tool to install any npm packages before importing them in code. If you decide to use a library that isn't part of the initial setup, you must run the appropriate install command (e.g. npm install some-package --yes) via the terminal tool. Do not assume a package is already available. Only Shadcn UI components and Tailwind (with its plugins) are preconfigured; everything else requires explicit installation.
+## Path Rules
 
-Shadcn UI dependencies — including radix-ui, lucide-react, class-variance-authority, and tailwind-merge — are already installed and must NOT be installed again. Tailwind CSS and its plugins are also preconfigured. Everything else requires explicit installation.
+- **writeFile / createOrUpdateFiles**: ALWAYS use relative paths (e.g. “app/page.tsx”). NEVER “/home/user/...”.
+- **readFile / listDirectory / searchFiles**: ALWAYS use absolute paths (e.g. “/home/user/app/page.tsx”).
+- Import alias “@/...” works in TypeScript only — NEVER use it in file system tools.
 
-3. Correct Shadcn UI Usage (No API Guesses): When using Shadcn UI components, strictly adhere to their actual API – do not guess props or variant names. If you're uncertain about how a Shadcn component works, inspect its source file under "@/components/ui/" using the readFiles tool or refer to official documentation. Use only the props and variants that are defined by the component.
-   - For example, a Button component likely supports a variant prop with specific options (e.g. "default", "outline", "secondary", "destructive", "ghost"). Do not invent new variants or props that aren’t defined – if a “primary” variant is not in the code, don't use variant="primary". Ensure required props are provided appropriately, and follow expected usage patterns (e.g. wrapping Dialog with DialogTrigger and DialogContent).
-   - Always import Shadcn components correctly from the "@/components/ui" directory. For instance:
-     import { Button } from "@/components/ui/button";
-     Then use: <Button variant="outline">Label</Button>
-  - You may import Shadcn components using the "@" alias, but when reading their files using readFiles, always convert "@/components/..." into "/home/user/components/..."
-  - Do NOT import "cn" from "@/components/ui/utils" — that path does not exist.
-  - The "cn" utility MUST always be imported from "@/lib/utils"
-  Example: import { cn } from "@/lib/utils"
+## Runtime Rules (Critical)
 
-Additional Guidelines:
-- Think step-by-step before coding
-- You MUST use the createOrUpdateFiles tool to make all file changes
-- When calling createOrUpdateFiles, always use relative file paths like "app/component.tsx"
-- You MUST use the terminal tool to install any packages
-- Do not print code inline
-- Do not wrap code in backticks
-- Use backticks (\`) for all strings to support embedded quotes safely.
-- Do not assume existing file contents — use readFiles if unsure
-- Do not include any commentary, explanation, or markdown — use only tool outputs
-- Always build full, real-world features or screens — not demos, stubs, or isolated widgets
-- Unless explicitly asked otherwise, always assume the task requires a full page layout — including all structural elements like headers, navbars, footers, content sections, and appropriate containers
-- Always implement realistic behavior and interactivity — not just static UI
-- Break complex UIs or logic into multiple components when appropriate — do not put everything into a single file
-- Use TypeScript and production-quality code (no TODOs or placeholders)
-- You MUST use Tailwind CSS for all styling — never use plain CSS, SCSS, or external stylesheets
-- Tailwind and Shadcn/UI components should be used for styling
-- Use Lucide React icons (e.g., import { SunIcon } from "lucide-react")
-- Use Shadcn components from "@/components/ui/*"
-- Always import each Shadcn component directly from its correct path (e.g. @/components/ui/button) — never group-import from @/components/ui
-- Use relative imports (e.g., "./weather-card") for your own components in app/
-- Follow React best practices: semantic HTML, ARIA where needed, clean useState/useEffect usage
-- Use only static/local data (no external APIs)
-- Responsive and accessible by default
-- Do not use local or external image URLs — instead rely on emojis and divs with proper aspect ratios (aspect-video, aspect-square, etc.) and color placeholders (e.g. bg-gray-200)
-- Every screen should include a complete, realistic layout structure (navbar, sidebar, footer, content, etc.) — avoid minimal or placeholder-only designs
-- Functional clones must include realistic features and interactivity (e.g. drag-and-drop, add/edit/delete, toggle states, localStorage if helpful)
-- Prefer minimal, working features over static or hardcoded content
-- Reuse and structure components modularly — split large screens into smaller files (e.g., Column.tsx, TaskCard.tsx, etc.) and import them
+- NEVER run: npm run dev, npm run build, npm run start, next dev, next build, next start.
+- These are BLOCKED. The build verification is handled externally after you finish.
+- The dev server hot-reloads when files change — you do not need to restart it.
 
-File conventions:
-- Write new components directly into app/ and split reusable logic into separate files where appropriate
-- Use PascalCase for component names, kebab-case for filenames
-- Use .tsx for components, .ts for types/utilities
-- Types/interfaces should be PascalCase in kebab-case files
-- Components should be using named exports
-- When using Shadcn components, import them from their proper individual file paths (e.g. @/components/ui/input)
+## Coding Standards
 
-Final output (MANDATORY):
-After ALL tool calls are 100% complete and the task is fully finished, respond with exactly the following format and NOTHING else:
+1. **”use client” at the TOP**: Add it as the very first line of app/page.tsx and any file using React hooks or browser APIs.
+
+2. **Dependencies**: Use installPackage before importing any library not listed below.
+   Pre-installed (do NOT re-install): shadcn/ui components, radix-ui, lucide-react, class-variance-authority, tailwind-merge, Tailwind CSS.
+
+3. **Shadcn UI**: Import from “@/components/ui/[component]”. Read the component source with readFile if unsure about props/variants — do NOT guess. Use only documented props.
+   - Import cn from “@/lib/utils” — never from “@/components/ui/utils”.
+
+4. **Styling**: Tailwind CSS only. Never create .css / .scss files.
+
+5. **Production quality**: Full layouts with navbar/sidebar/footer, realistic interactivity, proper state management, no TODOs, no placeholders.
+
+6. **Component structure**: Split complex UIs into separate component files. Use PascalCase names, kebab-case filenames, named exports.
+
+7. **Images**: No external image URLs. Use emojis, colored divs, or aspect-ratio containers instead.
+
+## Final Output (MANDATORY)
+
+After ALL tool calls are complete and the task is fully done, respond with EXACTLY:
 
 <task_summary>
-A short, high-level summary of what was created or changed.
+A short, high-level summary of what was built or changed.
 </task_summary>
 
-This marks the task as FINISHED. Do not include this early. Do not wrap it in backticks. Do not print it after each step. Print it once, only at the very end — never during or between tool usage.
-
-Example (correct):
-<task_summary>
-Created a blog layout with a responsive sidebar, a dynamic list of articles, and a detail page using Shadcn UI and Tailwind. Integrated the layout in app/page.tsx and added reusable components in app/.
-</task_summary>
-
-Incorrect:
-- Wrapping the summary in backticks
-- Including explanation or code after the summary
-- Ending without printing <task_summary>
-
-This is the ONLY valid way to terminate your task. If you omit or alter this section, the task will be considered incomplete and will continue unnecessarily.
+- Write this ONCE, at the very end.
+- Do NOT wrap in backticks.
+- Do NOT include anything after it.
+- Omitting this will keep the task running unnecessarily.
 `;
 
 export const ENHANCE_PROMPT = `

--- a/src/workflows/codegen.ts
+++ b/src/workflows/codegen.ts
@@ -9,7 +9,6 @@ import {
   createSandboxAdapter,
   connectSandboxAdapter,
 } from "@/codegen/sandbox";
-import { type ProjectModelKey } from "@/codegen/models";
 import {
   markGenerationJobCompleted,
   markGenerationJobFailed,
@@ -19,7 +18,7 @@ import {
 type CodegenWorkflowInput = {
   prompt: string;
   projectId: string;
-  model: ProjectModelKey | undefined;
+  model?: string;
   jobId?: string;
 };
 
@@ -63,7 +62,6 @@ async function runAgentStep(input: CodegenWorkflowInput, sandboxId: string) {
   return runCodegenAgent({
     prompt: input.prompt,
     history,
-    model: input.model,
     sandbox,
   });
 }
@@ -141,6 +139,15 @@ export async function codegenWorkflow(input: CodegenWorkflowInput) {
 
     const summary = result.summary?.trim();
     const hasFiles = Object.keys(result.files).length > 0;
+
+    if (result.buildError) {
+      const errorMessage = "The app was generated but failed to build: " + result.buildError.slice(0, 500);
+      await saveAssistantErrorStep(input.projectId, errorMessage);
+      if (input.jobId) {
+        await markJobFailedStep(input.jobId, errorMessage);
+      }
+      return { url: sandboxUrl, title: "Fragment", files: result.files, summary: errorMessage };
+    }
 
     if (!summary || !hasFiles) {
       const errorMessage = summary || "The generation finished without producing files.";

--- a/src/workflows/codegen.ts
+++ b/src/workflows/codegen.ts
@@ -3,6 +3,8 @@ import {
   generateFragmentTitle,
   generateUserFacingResponse,
   runCodegenAgent,
+  type AgentStreamEvent,
+  type AgentStreamWriter,
 } from "@/codegen/runtime";
 import { loadRecentProjectHistory } from "@/codegen/history";
 import {
@@ -14,6 +16,7 @@ import {
   markGenerationJobFailed,
   markGenerationJobRunning,
 } from "@/lib/generation-jobs";
+import { getWritable } from "workflow";
 
 type CodegenWorkflowInput = {
   prompt: string;
@@ -59,11 +62,27 @@ async function runAgentStep(input: CodegenWorkflowInput, sandboxId: string) {
   const sandbox = await connectSandboxAdapter(sandboxId);
   const history = await loadRecentProjectHistory(input.projectId, 5);
 
-  return runCodegenAgent({
-    prompt: input.prompt,
-    history,
-    sandbox,
-  });
+  // Get the workflow-native writable stream so the frontend can read events in real-time
+  const writable = getWritable<AgentStreamEvent>();
+  const writer = writable.getWriter();
+
+  const stream: AgentStreamWriter = {
+    write(event) {
+      // Fire-and-forget — we don't await so the agent loop isn't blocked by stream backpressure
+      writer.write(event).catch(() => {});
+    },
+  };
+
+  try {
+    return await runCodegenAgent({
+      prompt: input.prompt,
+      history,
+      sandbox,
+      stream,
+    });
+  } finally {
+    writer.close().catch(() => {});
+  }
 }
 
 async function getSandboxPreviewStep(sandboxId: string) {


### PR DESCRIPTION
## Summary

- **7-tool autonomous agent** — `writeFile`, `readFile`, `listDirectory`, `searchFiles`, `terminal`, `installPackage`, `createOrUpdateFiles` — replaces the 3-tool one-shot loop
- **Build-verify self-correction** — after generation, runs `next build`, feeds errors back to the model, retries up to 3× automatically
- **Real-time streaming** — agent events stream live to the frontend via Workflow SDK native streams (`getWritable`/`getReadable`) and SSE
- **Bi-directional communication** — agent can ask the user a clarifying question mid-generation via workflow hooks (`createHook`/`resumeHook`); user responds inline
- **Cancel generation** — Stop button aborts the workflow run and marks the job failed
- **Auto-reconnect** — stream hook retries up to 5× with linear backoff on network drop
- **Ask-user 5-min timeout** — agent auto-continues if user doesn't respond; countdown timer shown in UI
- **Error boundary** — stream render crashes show a clean error message instead of a blank panel
- **Cached sandbox connection** — E2B adapter caches the connection per adapter instance, no reconnect per tool call

## New API routes

- `GET /api/generation/[jobId]/stream` — SSE stream of agent events
- `POST /api/generation/[jobId]/respond` — resume a suspended agent question
- `POST /api/generation/[jobId]/cancel` — cancel a running generation

## Test plan

- [ ] Create a new project — verify agent streams tool calls in real time
- [ ] Check that build failures trigger fix attempts (visible in stream UI)
- [ ] Test the Stop button cancels generation
- [ ] Test ask-user: use an ambiguous prompt and verify the question appears inline
- [ ] Disconnect network mid-generation and verify auto-reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)